### PR TITLE
Require full repo context before lab work

### DIFF
--- a/.codex/notes.md
+++ b/.codex/notes.md
@@ -2,12 +2,26 @@
 
 ## Required reading before any task
 
-Read these files from the repo before starting work:
+Before creating, replacing, or modifying any lab, inspect the full repository file list, including hidden files and directories.
+
+Use a command that includes hidden paths and excludes Git internals, such as:
+
+```bash
+find . -path ./.git -prune -o -type f -print
+```
+
+Then read repository-level instruction and context files that may affect the task. Do not rely only on `rg --files`, because it can omit hidden files depending on ignore rules and configuration.
+
+Read these files from the repo before starting lab work:
 
 - AGENTS.md — your role, rules, and lab structure requirements
+- CLAUDE.md — Claude Code role, rules, and coordination expectations
+- README.md — repository overview and structure
+- .codex/notes.md — Codex-specific repository notes and lab context
 - shared/ip-plan.md — all lab IP addresses
 - shared/hardware-inventory.md — available hardware and roles
 - shared/common-commands.md — standard commands used across labs
+- shared/credentials.example.md — placeholder credential format, never store real secrets
 - templates/lab-template/ — the structure every lab must follow
 - agent-handoff/claude-to-codex.md — current instructions from Claude Code
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,13 +65,28 @@ Use this naming style:
 
 ## Reference files
 
-Before creating any lab, read these files from the repo:
+Before creating, replacing, or modifying any lab, inspect the full repository file list, including hidden files and directories.
 
+Use a command that includes hidden paths and excludes Git internals, such as:
+
+```bash
+find . -path ./.git -prune -o -type f -print
+```
+
+Then read repository-level instruction and context files that may affect the task, including hidden files. Do not rely only on `rg --files`, because it can omit hidden files depending on ignore rules and configuration.
+
+At minimum, read these files from the repo:
+
+- AGENTS.md — Codex role, rules, and lab structure requirements
+- CLAUDE.md — Claude Code role, rules, and coordination expectations
+- README.md — repository overview and structure
+- .codex/notes.md — Codex-specific repository notes and lab context
 - shared/ip-plan.md — lab IP addresses and network layout for all devices
 - shared/hardware-inventory.md — available physical and virtual hardware and their roles
 - shared/common-commands.md — standard commands used across labs
 - shared/credentials.example.md — placeholder credential format, never store real secrets
 - templates/lab-template/ — the required structure every lab must follow
+- agent-handoff/claude-to-codex.md — current instructions from Claude Code
 
 ## Agent coordination
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,28 @@ labs/000-lab-name/
 
 ## Reference files
 
-Before creating or reviewing any lab, read these files from the repo:
+Before creating, replacing, modifying, or reviewing any lab, inspect the full repository file list, including hidden files and directories.
 
+Use a command that includes hidden paths and excludes Git internals, such as:
+
+```bash
+find . -path ./.git -prune -o -type f -print
+```
+
+Then read repository-level instruction and context files that may affect the task, including hidden files. Do not rely only on `rg --files`, because it can omit hidden files depending on ignore rules and configuration.
+
+At minimum, read these files from the repo:
+
+- AGENTS.md — Codex role, rules, and lab structure requirements
+- CLAUDE.md — Claude Code role, rules, and coordination expectations
+- README.md — repository overview and structure
+- .codex/notes.md — Codex-specific repository notes and lab context
 - shared/ip-plan.md — lab IP addresses and network layout for all devices
 - shared/hardware-inventory.md — available physical and virtual hardware and their roles
 - shared/common-commands.md — standard commands used across labs
 - shared/credentials.example.md — placeholder credential format, never store real secrets
 - templates/lab-template/ — the required structure every lab must follow
+- agent-handoff/codex-to-claude.md — current instructions from Codex
 
 ## Agent coordination
 

--- a/agent-handoff/codex-to-claude.md
+++ b/agent-handoff/codex-to-claude.md
@@ -2,31 +2,18 @@
 
 ## Current task
 
-Replaced `labs/001-network-discovery` with `labs/001-confirm-lab-network`.
-
-This is a Level 0 baseline connectivity lab for confirming that the Mac host, Kali VM, and Raspberry Pi can reach each other on the lab network before later labs are run.
+Updated repository instructions so future lab work starts by inspecting all files, including hidden files and directories.
 
 ## Files changed
 
-- Deleted `labs/001-network-discovery/`.
-- Added `labs/001-confirm-lab-network/README.md`.
-- Added `labs/001-confirm-lab-network/objectives.md`.
-- Added `labs/001-confirm-lab-network/hardware.md`.
-- Added `labs/001-confirm-lab-network/topology.md`.
-- Added `labs/001-confirm-lab-network/setup.md`.
-- Added `labs/001-confirm-lab-network/instructions.md`.
-- Added `labs/001-confirm-lab-network/expected-output.md`.
-- Added `labs/001-confirm-lab-network/results.md`.
-- Added `labs/001-confirm-lab-network/cleanup.md`.
-- Added `labs/001-confirm-lab-network/lessons-learned.md`.
-- Added placeholder `.gitkeep` files under `configs/`, `results/screenshots/`, and `results/logs/`.
-- Updated `README.md` repo structure example to use the new lab directory name.
+- Updated `AGENTS.md` Reference files section to require full repository file discovery before creating, replacing, or modifying labs.
+- Added an explicit hidden-file-aware `find` example and warning not to rely only on `rg --files`.
+- Added repository-level reading requirements for `AGENTS.md`, `CLAUDE.md`, `README.md`, `.codex/notes.md`, shared files, templates, and `agent-handoff/claude-to-codex.md`.
+- Updated `.codex/notes.md` with the same hidden-file-aware discovery and reading requirements.
 
 ## Requested review
 
 Please check:
-- Commands are correct
-- Expected outputs are realistic
-- Cleanup is sufficient
-- Safety boundaries are clear
-- The Raspberry Pi subnet note is clear: `192.168.60.10` may require routing from `192.168.50.0/24`.
+- The new discovery rule is clear enough for future lab work.
+- The required reading list includes the right repository-level context files.
+- The `find` command is appropriate for listing hidden and visible files while excluding `.git`.

--- a/agent-handoff/codex-to-claude.md
+++ b/agent-handoff/codex-to-claude.md
@@ -10,6 +10,7 @@ Updated repository instructions so future lab work starts by inspecting all file
 - Added an explicit hidden-file-aware `find` example and warning not to rely only on `rg --files`.
 - Added repository-level reading requirements for `AGENTS.md`, `CLAUDE.md`, `README.md`, `.codex/notes.md`, shared files, templates, and `agent-handoff/claude-to-codex.md`.
 - Updated `.codex/notes.md` with the same hidden-file-aware discovery and reading requirements.
+- Addressed PR review follow-up by updating `CLAUDE.md` with matching hidden-file discovery guidance.
 
 ## Requested review
 
@@ -17,3 +18,4 @@ Please check:
 - The new discovery rule is clear enough for future lab work.
 - The required reading list includes the right repository-level context files.
 - The `find` command is appropriate for listing hidden and visible files while excluding `.git`.
+- `CLAUDE.md` and `AGENTS.md` are aligned for hidden-file discovery expectations.


### PR DESCRIPTION
## Summary
- Require full repository file discovery before creating, replacing, or modifying labs
- Add a hidden-file-aware `find` command example that excludes `.git`
- Add `.codex/notes.md`, `CLAUDE.md`, and `README.md` to required lab-work reading context
- Mirror the guidance in `.codex/notes.md`
- Update `agent-handoff/codex-to-claude.md`

## Validation
- `python3 scripts/scan-secrets.py`