### PR TITLE
Require static IPs for lab 001

### DIFF
--- a/agent-handoff/claude-to-codex.md
+++ b/agent-handoff/claude-to-codex.md
@@ -2,8 +2,25 @@
 
 ## Review result
 
-_No active review. Update this file when handing off work to Codex._
+Reviewed PR #5 (`codex/lab-001-static-ip-plan`) on 2026-04-29. Three issues must be fixed before merge. Full comments posted on the PR.
 
-## Required changes
+**Approved:**
+- `192.168.60.0/24` as current baseline (not future-only) — correct call.
+- NetworkManager examples for Kali and Raspberry Pi OS — commands are correct.
+- Task 0 gate, `results.md` gateway columns, topology and hardware changes — all good.
 
-_List specific changes needed before the PR can be merged._
+## Required changes before merge
+
+**1. `labs/001-confirm-lab-network/expected-output.md` — split merged code blocks**
+
+The Kali section and Raspberry Pi section each show `ip addr` and `ip route` output merged into one code block. They are separate commands with separate output. Split each into two labeled code blocks so a beginner knows which output comes from which command.
+
+Affects two sections: Kali IP address check (near top) and Raspberry Pi IP address check (near bottom).
+
+**2. `labs/001-confirm-lab-network/configs/kali-static-ip.example.md` and `configs/raspberry-pi-static-ip.example.md` — DNS placeholder note**
+
+Both files set `ipv4.dns` to the gateway IP. Add a note that this is a placeholder and `1.1.1.1` can be used if the lab router is not yet running a resolver. Lab 001 does not test DNS so this does not block the lab, but it will cause confusing failures in general system use.
+
+**3. `labs/001-confirm-lab-network/cleanup.md` — clarify static IPs are kept, not reverted**
+
+Step 4 says "Leave device network settings unchanged." Now that static IPs are a prerequisite assigned before the lab, a beginner could read this as an instruction to revert to DHCP. Change to: "Keep the static IP assignments in place. They are intentional and will be used by later labs."

--- a/agent-handoff/codex-to-claude.md
+++ b/agent-handoff/codex-to-claude.md
@@ -4,6 +4,14 @@
 
 Updated lab 001 so it requires the static IP plan from `shared/ip-plan.md` before validation.
 
+## PR feedback addressed
+
+Responded to Claude review feedback on PR #5:
+
+- Split the merged `ip addr` and `ip route` examples in `expected-output.md` into separate labeled output blocks.
+- Clarified that gateway DNS values in Kali and Raspberry Pi static-IP examples are placeholders, and `1.1.1.1` can be used if the lab router is not running DNS yet.
+- Updated `cleanup.md` so static IP assignments are kept in place for later labs.
+
 ## Files changed
 
 - Updated `shared/ip-plan.md` to make the current baseline static plan explicit:
@@ -21,7 +29,7 @@ Updated lab 001 so it requires the static IP plan from `shared/ip-plan.md` befor
 
 ## Validation
 
-- `python3 scripts/check-lab-structure.py labs/001-confirm-lab-network` passed.
+- `python3 scripts/check-lab-structure.py` passed.
 - `python3 scripts/scan-secrets.py` passed.
 
 ## Requested review

--- a/agent-handoff/codex-to-claude.md
+++ b/agent-handoff/codex-to-claude.md
@@ -2,20 +2,32 @@
 
 ## Current task
 
-Updated repository instructions so future lab work starts by inspecting all files, including hidden files and directories.
+Updated lab 001 so it requires the static IP plan from `shared/ip-plan.md` before validation.
 
 ## Files changed
 
-- Updated `AGENTS.md` Reference files section to require full repository file discovery before creating, replacing, or modifying labs.
-- Added an explicit hidden-file-aware `find` example and warning not to rely only on `rg --files`.
-- Added repository-level reading requirements for `AGENTS.md`, `CLAUDE.md`, `README.md`, `.codex/notes.md`, shared files, templates, and `agent-handoff/claude-to-codex.md`.
-- Updated `.codex/notes.md` with the same hidden-file-aware discovery and reading requirements.
-- Addressed PR review follow-up by updating `CLAUDE.md` with matching hidden-file discovery guidance.
+- Updated `shared/ip-plan.md` to make the current baseline static plan explicit:
+  - Attacker/Admin network: `192.168.50.0/24`, gateway `192.168.50.1`
+  - Target network: `192.168.60.0/24`, gateway `192.168.60.1`
+- Updated `labs/001-confirm-lab-network/` docs so lab 001 expects:
+  - Kali VM: `192.168.50.10/24`
+  - Mac host: `192.168.50.20/24`
+  - Raspberry Pi 1: `192.168.60.10/24`
+- Added static-IP examples under `labs/001-confirm-lab-network/configs/`:
+  - `macos-static-ip.example.md`
+  - `kali-static-ip.example.md`
+  - `raspberry-pi-static-ip.example.md`
+- Updated `results.md` to capture expected and observed gateways, unexpected IPs, and devices still using DHCP.
+
+## Validation
+
+- `python3 scripts/check-lab-structure.py labs/001-confirm-lab-network` passed.
+- `python3 scripts/scan-secrets.py` passed.
 
 ## Requested review
 
 Please check:
-- The new discovery rule is clear enough for future lab work.
-- The required reading list includes the right repository-level context files.
-- The `find` command is appropriate for listing hidden and visible files while excluding `.git`.
-- `CLAUDE.md` and `AGENTS.md` are aligned for hidden-file discovery expectations.
+
+- The static addressing requirement is clear enough for a beginner running lab 001.
+- The NetworkManager examples are acceptable for Kali and Raspberry Pi OS in this lab context.
+- The repo should treat `192.168.60.0/24` as part of the current baseline now, not future-only.

--- a/labs/001-confirm-lab-network/README.md
+++ b/labs/001-confirm-lab-network/README.md
@@ -10,25 +10,28 @@ Confirm that the Mac, Kali VM, and Raspberry Pi can reach each other on the lab 
 
 ## Lab summary
 
-This lab verifies basic network connectivity between the admin workstation, attacker VM, and Linux target. You will confirm each device's IP address, send ICMP echo requests with `ping`, inspect neighbor entries with `arp`, and record the results.
+This lab verifies basic network connectivity between the admin workstation, attacker VM, and Linux target after static IP addresses have been assigned from the repo IP plan. You will confirm each device's IP address, send ICMP echo requests with `ping`, inspect neighbor entries with `arp`, and record the results.
 
-This lab does not require logging into third-party systems, changing device configuration, scanning public networks, or modifying live lab machines.
+This lab does not require logging into third-party systems, scanning public networks, or modifying non-lab machines. Static IP assignment is a prerequisite on owned lab devices and is documented under `configs/`.
 
 ## Tools used
 
 - `ip addr`
+- `ip route`
 - `ping`
 - `arp`
 
 ## Lab IPs
 
-The expected IP addresses come from `shared/ip-plan.md`.
+The expected IP addresses come from `shared/ip-plan.md`. Lab 001 should not be marked complete until these static addresses are observed.
 
 | Device | Role | Expected IP |
 | --- | --- | --- |
 | Kali VM | Attacker | `192.168.50.10` |
 | Mac host | Admin workstation | `192.168.50.20` |
 | Raspberry Pi 1 | Linux target | `192.168.60.10` |
+
+Static IP configuration examples are stored in `configs/`.
 
 ## Files in this lab
 

--- a/labs/001-confirm-lab-network/cleanup.md
+++ b/labs/001-confirm-lab-network/cleanup.md
@@ -5,7 +5,7 @@
 1. Stop any `ping` command that is still running by pressing `Ctrl+C` in that terminal.
 2. Save any useful command output under `results/logs/`.
 3. Remove accidental non-lab data from `results.md` or `results/logs/`.
-4. Leave device network settings unchanged.
+4. Keep the static IP assignments in place. They are intentional and will be used by later labs.
 5. Shut down the Kali VM or Raspberry Pi only if your normal lab workflow calls for it.
 
 ## Validation

--- a/labs/001-confirm-lab-network/configs/kali-static-ip.example.md
+++ b/labs/001-confirm-lab-network/configs/kali-static-ip.example.md
@@ -1,0 +1,55 @@
+# Kali Static IP Example
+
+Use this as a checklist for assigning the Kali address from `shared/ip-plan.md`.
+
+## Target values
+
+| Setting | Value |
+| --- | --- |
+| IP address | `192.168.50.10` |
+| Prefix | `/24` |
+| Gateway | `192.168.50.1` |
+| DNS | `192.168.50.1`, or a lab-approved DNS resolver |
+
+## NetworkManager example
+
+Run this on Kali after replacing `CONNECTION_NAME` with the active lab connection name.
+
+Find the connection name:
+
+```bash
+nmcli connection show
+```
+
+Assign the static address:
+
+```bash
+sudo nmcli connection modify "CONNECTION_NAME" \
+  ipv4.method manual \
+  ipv4.addresses 192.168.50.10/24 \
+  ipv4.gateway 192.168.50.1 \
+  ipv4.dns 192.168.50.1
+```
+
+Reconnect:
+
+```bash
+sudo nmcli connection down "CONNECTION_NAME"
+sudo nmcli connection up "CONNECTION_NAME"
+```
+
+## Verification
+
+Run this on Kali:
+
+```bash
+ip addr
+ip route
+ping -c 4 192.168.50.20
+```
+
+Expected result:
+
+- The lab interface shows `192.168.50.10/24`.
+- The default or lab route uses `192.168.50.1` when the lab router is available.
+- Kali can reach the Mac at `192.168.50.20`.

--- a/labs/001-confirm-lab-network/configs/kali-static-ip.example.md
+++ b/labs/001-confirm-lab-network/configs/kali-static-ip.example.md
@@ -9,7 +9,7 @@ Use this as a checklist for assigning the Kali address from `shared/ip-plan.md`.
 | IP address | `192.168.50.10` |
 | Prefix | `/24` |
 | Gateway | `192.168.50.1` |
-| DNS | `192.168.50.1`, or a lab-approved DNS resolver |
+| DNS | `192.168.50.1` placeholder; use `1.1.1.1` if the lab router is not yet running a resolver |
 
 ## NetworkManager example
 

--- a/labs/001-confirm-lab-network/configs/macos-static-ip.example.md
+++ b/labs/001-confirm-lab-network/configs/macos-static-ip.example.md
@@ -1,0 +1,39 @@
+# macOS Static IP Example
+
+Use this as a checklist for assigning the Mac host address from `shared/ip-plan.md`.
+
+## Target values
+
+| Setting | Value |
+| --- | --- |
+| IP address | `192.168.50.20` |
+| Subnet mask | `255.255.255.0` |
+| Gateway/router | `192.168.50.1` |
+| DNS | `192.168.50.1`, or a lab-approved DNS resolver |
+
+## GUI method
+
+1. Open System Settings.
+2. Go to Network.
+3. Select the interface connected to the lab network.
+4. Open Details.
+5. Set IPv4 configuration to Manual.
+6. Enter the target values above.
+7. Apply the change.
+8. Confirm the Mac shows `192.168.50.20`.
+
+## Command-line verification
+
+Run this on the Mac:
+
+```bash
+ifconfig
+netstat -rn
+ping -c 4 192.168.50.10
+```
+
+Expected result:
+
+- The lab interface shows `192.168.50.20`.
+- The route table includes a path through `192.168.50.1` when the lab router is available.
+- The Mac can reach Kali at `192.168.50.10`.

--- a/labs/001-confirm-lab-network/configs/raspberry-pi-static-ip.example.md
+++ b/labs/001-confirm-lab-network/configs/raspberry-pi-static-ip.example.md
@@ -1,0 +1,58 @@
+# Raspberry Pi Static IP Example
+
+Use this as a checklist for assigning the Raspberry Pi address from `shared/ip-plan.md`.
+
+## Target values
+
+| Setting | Value |
+| --- | --- |
+| IP address | `192.168.60.10` |
+| Prefix | `/24` |
+| Gateway | `192.168.60.1` |
+| DNS | `192.168.60.1`, or a lab-approved DNS resolver |
+
+## NetworkManager example
+
+Use the Raspberry Pi's directly connected monitor and keyboard. Do not SSH into the Pi for this setup unless a separate instruction explicitly allows it.
+
+Find the connection name:
+
+```bash
+nmcli connection show
+```
+
+Assign the static address after replacing `CONNECTION_NAME` with the active lab connection name:
+
+```bash
+sudo nmcli connection modify "CONNECTION_NAME" \
+  ipv4.method manual \
+  ipv4.addresses 192.168.60.10/24 \
+  ipv4.gateway 192.168.60.1 \
+  ipv4.dns 192.168.60.1
+```
+
+Reconnect:
+
+```bash
+sudo nmcli connection down "CONNECTION_NAME"
+sudo nmcli connection up "CONNECTION_NAME"
+```
+
+## Verification
+
+Run this on the Raspberry Pi:
+
+```bash
+ip addr
+ip route
+ping -c 4 192.168.60.1
+ping -c 4 192.168.50.10
+```
+
+Expected result:
+
+- The lab interface shows `192.168.60.10/24`.
+- The route table uses `192.168.60.1` when the lab router is available.
+- The Raspberry Pi can reach Kali at `192.168.50.10` when routing between lab subnets is available.
+
+If `nmcli` is not available, record that in `results.md` and use the Raspberry Pi OS network configuration method for the installed OS version. Do not store passwords or real secrets in this repo.

--- a/labs/001-confirm-lab-network/configs/raspberry-pi-static-ip.example.md
+++ b/labs/001-confirm-lab-network/configs/raspberry-pi-static-ip.example.md
@@ -9,7 +9,7 @@ Use this as a checklist for assigning the Raspberry Pi address from `shared/ip-p
 | IP address | `192.168.60.10` |
 | Prefix | `/24` |
 | Gateway | `192.168.60.1` |
-| DNS | `192.168.60.1`, or a lab-approved DNS resolver |
+| DNS | `192.168.60.1` placeholder; use `1.1.1.1` if the lab router is not yet running a resolver |
 
 ## NetworkManager example
 

--- a/labs/001-confirm-lab-network/expected-output.md
+++ b/labs/001-confirm-lab-network/expected-output.md
@@ -13,10 +13,17 @@ ip route
 
 Expected example:
 
+`ip addr` example:
+
 ```text
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
     inet 192.168.50.10/24 brd 192.168.50.255 scope global eth0
-default via 192.168.50.1 dev eth0
+```
+
+`ip route` example:
+
+```text
+default via 192.168.50.1 dev eth0 proto static metric 100
 ```
 
 ## Kali to Mac ping
@@ -147,10 +154,17 @@ ip route
 
 Expected example:
 
+`ip addr` example:
+
 ```text
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
     inet 192.168.60.10/24 brd 192.168.60.255 scope global eth0
-default via 192.168.60.1 dev eth0
+```
+
+`ip route` example:
+
+```text
+default via 192.168.60.1 dev eth0 proto static metric 100
 ```
 
 ## Raspberry Pi to Kali ping

--- a/labs/001-confirm-lab-network/expected-output.md
+++ b/labs/001-confirm-lab-network/expected-output.md
@@ -8,6 +8,7 @@ Command:
 
 ```bash
 ip addr
+ip route
 ```
 
 Expected example:
@@ -15,6 +16,7 @@ Expected example:
 ```text
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
     inet 192.168.50.10/24 brd 192.168.50.255 scope global eth0
+default via 192.168.50.1 dev eth0
 ```
 
 ## Kali to Mac ping
@@ -140,6 +142,7 @@ Command:
 
 ```bash
 ip addr
+ip route
 ```
 
 Expected example:
@@ -147,6 +150,7 @@ Expected example:
 ```text
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
     inet 192.168.60.10/24 brd 192.168.60.255 scope global eth0
+default via 192.168.60.1 dev eth0
 ```
 
 ## Raspberry Pi to Kali ping

--- a/labs/001-confirm-lab-network/hardware.md
+++ b/labs/001-confirm-lab-network/hardware.md
@@ -24,4 +24,5 @@ The available devices come from `shared/hardware-inventory.md`.
 
 - Use only owned lab devices.
 - Do not SSH into devices during this lab unless a separate instruction explicitly allows it.
-- Do not change IP addresses, firewall rules, router settings, or switch settings as part of this lab.
+- Assign static IP addresses before running the validation tasks.
+- Do not change firewall rules, router settings, or switch settings as part of this lab.

--- a/labs/001-confirm-lab-network/instructions.md
+++ b/labs/001-confirm-lab-network/instructions.md
@@ -4,18 +4,32 @@
 
 Run these commands only on the Mac, Kali VM, and Raspberry Pi that belong to this lab. Do not test public IP addresses, third-party networks, or production systems.
 
+## Task 0: Confirm static IP assignment is complete
+
+Before starting the reachability checks, confirm the static IP examples in `configs/` have been applied to the owned lab devices:
+
+- Mac host: `192.168.50.20`
+- Kali VM: `192.168.50.10`
+- Raspberry Pi: `192.168.60.10`
+
+Expected behavior:
+Each device shows the static IP assigned in `shared/ip-plan.md`.
+
+If any device still has a DHCP address or an unexpected subnet, stop and fix the static IP assignment before continuing. Record the mismatch in `results.md`.
+
 ## Task 1: Confirm the Kali VM IP address
 
 Run this on Kali:
 
 ```bash
 ip addr
+ip route
 ```
 
 Expected behavior:
-Kali shows an active network interface with `inet 192.168.50.10/24`. The interface name may be `eth0`, `ens33`, `enp0s3`, or another Linux interface name.
+Kali shows an active network interface with `inet 192.168.50.10/24`. The route table uses `192.168.50.1` when the lab router is available. The interface name may be `eth0`, `ens33`, `enp0s3`, or another Linux interface name.
 
-Record the interface name and IP address in `results.md`.
+Record the interface name, IP address, and gateway in `results.md`.
 
 ## Task 2: Confirm Kali can reach the Mac
 
@@ -39,7 +53,7 @@ ping -c 4 192.168.60.10
 ```
 
 Expected behavior:
-If routing between the lab subnets is configured, Kali receives replies from the Raspberry Pi.
+If routing between the static lab subnets is configured, Kali receives replies from the Raspberry Pi.
 
 If the command shows `Destination Host Unreachable`, `Network is unreachable`, or `100% packet loss`, record the exact result. Because the Raspberry Pi IP is reserved in `192.168.60.0/24`, failure is expected when no router connects the `192.168.50.0/24` and `192.168.60.0/24` networks.
 
@@ -105,13 +119,14 @@ Run these on the Raspberry Pi:
 
 ```bash
 ip addr
+ip route
 arp -n
 ```
 
 Expected behavior:
-The Raspberry Pi shows `inet 192.168.60.10/24` on its active interface. The ARP table may show a router or gateway entry if traffic crosses subnets.
+The Raspberry Pi shows `inet 192.168.60.10/24` on its active interface. The route table uses `192.168.60.1` when the lab router is available. The ARP table may show a router or gateway entry if traffic crosses subnets.
 
-Record the active interface name, IP address, and any relevant ARP entries in `results.md`.
+Record the active interface name, IP address, gateway, and any relevant ARP entries in `results.md`.
 
 ## Task 9: Summarize pass or fail
 

--- a/labs/001-confirm-lab-network/objectives.md
+++ b/labs/001-confirm-lab-network/objectives.md
@@ -13,5 +13,6 @@ By the end of this lab, you should be able to:
 
 - The Kali VM is using `192.168.50.10`.
 - The Mac host is reachable at `192.168.50.20`.
-- The Raspberry Pi is reachable at `192.168.60.10`, or the routing gap is documented clearly.
+- The Raspberry Pi is using `192.168.60.10`.
+- The Raspberry Pi is reachable from Kali, or the missing route between static subnets is documented clearly.
 - `results.md` contains actual command results and next actions.

--- a/labs/001-confirm-lab-network/results.md
+++ b/labs/001-confirm-lab-network/results.md
@@ -10,11 +10,11 @@ Lab operator:
 
 ## Expected devices
 
-| Device | Expected IP | Observed IP | Status |
-| --- | --- | --- | --- |
-| Kali VM | `192.168.50.10` |  |  |
-| Mac host | `192.168.50.20` |  |  |
-| Raspberry Pi 1 | `192.168.60.10` |  |  |
+| Device | Expected IP | Expected gateway | Observed IP | Observed gateway | Status |
+| --- | --- | --- | --- | --- | --- |
+| Kali VM | `192.168.50.10` | `192.168.50.1` |  |  |  |
+| Mac host | `192.168.50.20` | `192.168.50.1` |  |  |  |
+| Raspberry Pi 1 | `192.168.60.10` | `192.168.60.1` |  |  |  |
 
 ## Reachability matrix
 
@@ -49,5 +49,6 @@ results/screenshots/
 
 - Routing needed between `192.168.50.0/24` and `192.168.60.0/24`:
 - Devices with unexpected IP addresses:
+- Devices still using DHCP:
 - Commands that failed:
 - Notes before starting Level 1 labs:

--- a/labs/001-confirm-lab-network/setup.md
+++ b/labs/001-confirm-lab-network/setup.md
@@ -7,6 +7,7 @@
 - Confirm the devices are connected to the intended lab network.
 - Confirm the expected IP addresses in `shared/ip-plan.md`.
 - Keep `shared/credentials.example.md` as the only credential reference. Do not record real passwords.
+- Use the Raspberry Pi's directly connected monitor and keyboard. Do not SSH into the Pi for this lab.
 
 ## Expected addresses
 
@@ -15,6 +16,39 @@
 | Kali VM | `192.168.50.10` |
 | Mac host | `192.168.50.20` |
 | Raspberry Pi 1 | `192.168.60.10` |
+
+## Static IP prerequisite
+
+Before running the validation tasks, assign the static addresses above using the examples in `configs/`:
+
+- `configs/macos-static-ip.example.md`
+- `configs/kali-static-ip.example.md`
+- `configs/raspberry-pi-static-ip.example.md`
+
+Use the router or firewall gateway from `shared/ip-plan.md` when the segmented lab network is available:
+
+| Network | Gateway |
+| --- | --- |
+| `192.168.50.0/24` | `192.168.50.1` |
+| `192.168.60.0/24` | `192.168.60.1` |
+
+If the Raspberry Pi still shows a DHCP address, stop and fix the static assignment before continuing.
+
+## Verify assigned addresses
+
+Run this on Kali and the Raspberry Pi:
+
+```bash
+ip addr
+ip route
+```
+
+On the Mac, confirm the static address in System Settings or with:
+
+```bash
+ifconfig
+netstat -rn
+```
 
 ## Prepare result folders
 
@@ -31,8 +65,8 @@ Before running the tasks, update `results.md` with:
 - Date
 - Device names
 - Observed IP addresses
-- Whether the Raspberry Pi is expected to be routed from `192.168.50.0/24` to `192.168.60.0/24`
+- Whether the observed IPs match the static IP plan
 
 ## No live-system changes
 
-Do not change network settings during this lab. If a command fails, record the failure and use the troubleshooting notes as follow-up work.
+Do not improvise new IP addresses during this lab. If a command fails, record the failure and use the troubleshooting notes as follow-up work.

--- a/labs/001-confirm-lab-network/topology.md
+++ b/labs/001-confirm-lab-network/topology.md
@@ -7,7 +7,7 @@
 | Kali VM | Attacker | `192.168.50.10` | `192.168.50.0/24` | Runs confirmation commands |
 | Mac host | Admin workstation | `192.168.50.20` | `192.168.50.0/24` | Hosts Kali VM |
 | Raspberry Pi 1 | Linux target | `192.168.60.10` | `192.168.60.0/24` | Target for later Linux labs |
-| pfSense or OPNsense | Router and firewall | `192.168.50.1` | `192.168.50.0/24` | Planned or optional router |
+| pfSense or OPNsense | Router and firewall | `192.168.50.1`, `192.168.60.1` | Lab gateway | Routes between lab subnets when available |
 
 ## Diagram
 
@@ -20,12 +20,13 @@
        | Ethernet or virtual network
        |
   Lab switch / router  <-------->  Raspberry Pi 1
-  192.168.50.1 optional            192.168.60.10
+  192.168.50.1 / 192.168.60.1      192.168.60.10
 ```
 
 ## Network notes
 
 - The Mac and Kali VM are expected on `192.168.50.0/24`.
-- The Raspberry Pi is reserved as `192.168.60.10`, which is a different subnet from Kali and the Mac.
-- If there is no router between `192.168.50.0/24` and `192.168.60.0/24`, pings to the Raspberry Pi may fail. Record that result instead of changing live network settings.
+- The Raspberry Pi is expected on `192.168.60.0/24`.
+- A router or firewall path is required between `192.168.50.0/24` and `192.168.60.0/24`.
+- If there is no router between the two static subnets, pings to the Raspberry Pi may fail. Record that result instead of changing live network settings.
 - This lab confirms baseline reachability only. It does not perform port scanning, exploitation, password guessing, or service enumeration.

--- a/shared/ip-plan.md
+++ b/shared/ip-plan.md
@@ -1,10 +1,13 @@
 # IP Plan
 
-## Current simple lab
+## Current baseline static plan
 
-| Network | Purpose | CIDR |
-|---|---|---|
-| Lab network | Basic sandbox | 192.168.50.0/24 |
+| Network | Purpose | CIDR | Gateway |
+|---|---|---|---|
+| Attacker/Admin | Mac and Kali baseline network | 192.168.50.0/24 | 192.168.50.1 |
+| Target | Raspberry Pi baseline target network | 192.168.60.0/24 | 192.168.60.1 |
+
+The Raspberry Pi target is assigned a static address in `192.168.60.0/24`. Routing between `192.168.50.0/24` and `192.168.60.0/24` is required before cross-subnet reachability checks can pass.
 
 ## Future segmented lab
 


### PR DESCRIPTION
## Summary
- require lab 001 to use the static IP plan from shared/ip-plan.md
- add static-IP examples for macOS, Kali, and Raspberry Pi
- update lab 001 setup, instructions, expected output, topology, and results templates for gateway validation
- update Codex-to-Claude handoff with review focus

## Validation
- python3 scripts/check-lab-structure.py
- python3 scripts/scan-secrets.py